### PR TITLE
Update sphinx URL that gets redirected

### DIFF
--- a/astropy_sphinx_theme/bootstrap-astropy/layout.html
+++ b/astropy_sphinx_theme/bootstrap-astropy/layout.html
@@ -86,7 +86,7 @@
     {%- endif %}
     {%- endif %}
     {%- if show_sphinx %}
-    {% trans sphinx_version=sphinx_version|e %}Created using <a href="http://sphinx.pocoo.org/">Sphinx</a> {{ sphinx_version }}.{% endtrans %} &nbsp;
+    {% trans sphinx_version=sphinx_version|e %}Created using <a href="http://www.sphinx-doc.org/en/stable/">Sphinx</a> {{ sphinx_version }}.{% endtrans %} &nbsp;
     {%- endif %}
     {%- if last_updated %}
     {% trans last_updated=last_updated|e %}Last built {{ last_updated }}.{% endtrans %} <br/>


### PR DESCRIPTION
Replaced sphinx URL in footer by the sphinx-doc.org domain that changed a while ago. There is a permanent redirect in place at the moment.