### PR TITLE
Change css styling to render dropdown menu horizontal instead of vertical

### DIFF
--- a/astropy_sphinx_theme/bootstrap-astropy/static/bootstrap-astropy.css
+++ b/astropy_sphinx_theme/bootstrap-astropy/static/bootstrap-astropy.css
@@ -315,8 +315,9 @@ div.dropdown {
 div.dropdown-content {
     display: none; /* Fix this at none */
     background-color: DimGray;
-    width: 500px;
-    height: 50px;
+    color: White;
+    width: 235px;
+    height: 155px;
     box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
     padding-top: 3px; 
     padding-right: 15px;


### PR DESCRIPTION
Fixes #7. 

Made changes to the `bootstrap-astropy.css` file so that the dropdown menu item is vertically arranged instead of being horizontal.