### PR TITLE
Make navigation sidebar sticky using CSS

### DIFF
--- a/astropy_sphinx_theme/bootstrap-astropy/static/bootstrap-astropy.css
+++ b/astropy_sphinx_theme/bootstrap-astropy/static/bootstrap-astropy.css
@@ -487,6 +487,10 @@ div.sphinxsidebar {
 
 div.sphinxsidebarwrapper {
     padding: 0px 0px 0px 5px;
+    position: sticky;
+    height: calc(100vh - 1em);
+    overflow-y: auto;
+    top: 0;
 }
 
 div.sphinxsidebar h3 {


### PR DESCRIPTION
Fixes issue #11, but the behaviour for a long ToC (that overflows the element) is a bit different.