### PR TITLE
Fix the width of the topbar

### DIFF
--- a/astropy_sphinx_theme/bootstrap-astropy/static/bootstrap-astropy.css
+++ b/astropy_sphinx_theme/bootstrap-astropy/static/bootstrap-astropy.css
@@ -237,6 +237,7 @@ div.topbar {
   overflow-x: hidden;
   overflow-y: hidden;
   width: 100%;
+  box-sizing: border-box;
 }
 
 div.topbar a.brand {


### PR DESCRIPTION
Adds the `box-sizing: border-box;` CSS property to `div.topbar` as mentioned in the comments in #12.

Fixes the first part of #12: with this fix, the horizontal scrollbar is no longer present when the window is wide enough.

The second part of #12 still remains: when the window width is too small (so a horizontal scrollbar appears), the sidebar collapse indicator `<<` can still move off the sidebar indicator. This seems to be a separate issue.