### PR TITLE
DEP: drop dangling runtime dependency on setuptools

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,10 +19,6 @@ long_description_content_type = text/x-rst
 zip_safe = False
 packages = find:
 python_requires = >=3.7
-setup_requires =
-    setuptools_scm
-install_requires =
-    setuptools>=30.3.0
 
 [options.extras_require]
 test =


### PR DESCRIPTION
Found by running the following command from `astropy/`:
```
❯ uv tree --package setuptools --invert
Resolved 166 packages in 11ms
asdf-astropy v0.7.0
├── astropy v7.1.dev253+g4a55b10002 (extra: all)
│   └── asdf-astropy v0.7.0 (*)
├── astropy v7.1.dev253+g4a55b10002 (extra: dev-all) (*)
└── astropy v7.1.dev253+g4a55b10002 (extra: test-all) (*)
setuptools v75.6.0
└── astropy-sphinx-theme v1.1
    └── sphinx-astropy v1.9.1
        ├── astropy[confv2] v7.1.dev253+g4a55b10002 (extra: dev) (*)
        ├── astropy[confv2] v7.1.dev253+g4a55b10002 (extra: dev-all) (*)
        └── astropy[confv2] v7.1.dev253+g4a55b10002 (extra: docs) (*)
```

I find that this package doesn't actually require setuptools at runtime, so I assume it was listed by mistake when it should only have been a build-time requirement.