### PR TITLE
Fix overflow on nav sidebar

### DIFF
--- a/astropy_sphinx_theme/bootstrap-astropy/static/bootstrap-astropy.css
+++ b/astropy_sphinx_theme/bootstrap-astropy/static/bootstrap-astropy.css
@@ -512,6 +512,7 @@ div.sphinxsidebar p.topless {
 div.sphinxsidebar ul {
     margin: 0px 0px 0px 5px;
     padding: 0;
+    overflow-x: auto;
 }
 
 div.sphinxsidebar ul ul {


### PR DESCRIPTION
Adding `overflow-x: auto` to the first level unordered list in `sphinxsidebar` so that overflow text is made to scroll and not cover the main content on the page.

Closes #39 