### PR TITLE
Updated release infrastructure

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  exclude:
+    authors:
+      - pre-commit-ci
+  categories:
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: New Features
+      labels:
+        - enhancement
+    - title: Documentation
+      labels:
+        - Documentation
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,56 +3,38 @@ name: Release
 on:
   pull_request:
   push:
+    branches:
+      - main
     tags:
-      - "*"
+      - "v*"
+  workflow_dispatch:
 
 permissions: {}
 
 jobs:
   build:
-    name: Build and publish Python 🐍 distributions 📦 to PyPI
-    runs-on: ubuntu-latest
-    if: ((github.event_name == 'push' && startsWith(github.ref, 'refs/tags')) || contains(github.event.pull_request.labels.*.name, 'Build wheels'))
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@e97344095b099e1d729fe97429078c9975921d8a # v2
+    with:
+      save_artifacts: true
+      upload_to_pypi: false
+      test_extras: test
+      test_command: pytest --pyargs astropy_sphinx_theme
 
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: 3.11
-
-      - name: Install python-build and twine
-        run: python -m pip install build "twine>=3.3"
-
-      - name: Build package
-        run: python -m build --sdist --wheel .
-
-      - name: List result
-        run: ls -l dist
-
-      - name: Check long_description
-        run: python -m twine check --strict dist/*
-
-      - name: Test package
-        run: |
-          cd ..
-          python -m venv testenv
-          testenv/bin/pip install pytest sphinx astropy-sphinx-theme/dist/*.whl
-          testenv/bin/pytest astropy-sphinx-theme/astropy_sphinx_theme/tests
-
-  pypi-publish:
-    if: startsWith(github.ref, 'refs/tags')
-    needs: [build]
+  upload:
+    if: startsWith(github.ref, 'refs/tags/v')
     name: Upload release to PyPI
     runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/astropy-sphinx-theme
+    needs: [build]
+    environment: pypi
     permissions:
       id-token: write
     steps:
-      - name: Publish distribution 📦 to PyPI
-        if: startsWith(github.ref, 'refs/tags')
+      - name: Download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          merge-multiple: true
+          pattern: dist-*
+          path: dist
+
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -1,0 +1,37 @@
+# This workflow takes the GitHub release notes and updates the changelog on the
+# main branch with the body of the release notes, thereby keeping a log in
+# the git repo of the changes.
+
+name: "Update Changelog"
+
+on:
+  release:
+    types: [released]
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Update Changelog
+        uses: stefanzweifel/changelog-updater-action@a938690fad7edf25368f37e43a1ed1b34303eb36 # v1
+        with:
+          release-notes: ${{ github.event.release.body }}
+          latest-version: ${{ github.event.release.name }}
+          path-to-changelog: CHANGES.md
+
+      - name: Commit updated CHANGELOG
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
+        with:
+          branch: main
+          commit_message: Update CHANGELOG
+          file_pattern: CHANGES.md

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,24 +1,16 @@
-2.1 (unreleased)
-----------------
+# Changelog
 
-- No changes yet
-
-2.0 (2025-03-18)
-----------------
+## 2.0 (2025-03-18)
 
 - Infrastructure updates. Minimum Python version is now 3.7. [#27]
-
 - Fixed overflowing navbar. [#40]
 
-1.1 (2019-04-25)
-----------------
+## 1.1 (2019-04-25)
 
-- Added a theme option ``astropy_project_menubar`` which can be used to control
+- Added a theme option `astropy_project_menubar` which can be used to control
   whether to show extra project links in the top bar. [#4, #8]
-
 - Fixed compatibility with Sphinx 2.x. [#6]
 
-1.0 (2018-01-26)
-----------------
+## 1.0 (2018-01-26)
 
 - Initial standalone version of the theme (formerly packaged as part of astropy-helpers)


### PR DESCRIPTION
This makes it so we can do the releases through GitHub and have the changelog be automatically updated from the GitHub release description as done in several other packages (e.g. reproject)