### PR TITLE
Set collapse_navigation back to True to speed up build

### DIFF
--- a/astropy_sphinx_theme/astropy-unified/theme.toml
+++ b/astropy_sphinx_theme/astropy-unified/theme.toml
@@ -4,6 +4,11 @@ inherit = "sunpy"
 [options]
 sst_project_name = "Astropy"
 sst_site_root = "https://astropy.org"
+# Prune sibling branches in the sidebar toctree so each page only renders
+# its own ancestry. Pydata defaults this to False; astropy's docs have
+# 1400+ pages reachable from a single top-level section, so without this
+# every page's sidebar would contain the entire user guide.
+collapse_navigation = "True"
 navbar_links = [
     ["About",
         [


### PR DESCRIPTION
As otherwise the sidebar contains a tree of whole astropy documentation, which slows down the documentation build a lot. With this PR, the documentation build is around 4x faster for me.

When we were using the vanilla pydata theme before, we had this set in ``html_theme_options``.